### PR TITLE
fix(ci): unblock deploy — repo-scoped secrets and complete guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ jobs:
   deploy:
     name: Build and deploy to Plesk
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,12 +55,23 @@ jobs:
           USER: ${{ secrets.DEPLOY_USER }}
           TARGET: ${{ secrets.DEPLOY_PATH }}
           KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
         run: |
-          if [ -n "$HOST" ] && [ -n "$USER" ] && [ -n "$TARGET" ] && [ -n "$KEY" ]; then
+          missing=""
+          [ -n "$HOST" ]        || missing="$missing DEPLOY_HOST"
+          [ -n "$USER" ]        || missing="$missing DEPLOY_USER"
+          [ -n "$TARGET" ]      || missing="$missing DEPLOY_PATH"
+          [ -n "$KEY" ]         || missing="$missing DEPLOY_SSH_KEY"
+          # Without this the SSH step writes an empty known_hosts and the
+          # connection dies on host key verification, so it gates the deploy
+          # like any other required secret.
+          [ -n "$KNOWN_HOSTS" ] || missing="$missing DEPLOY_KNOWN_HOSTS"
+
+          if [ -z "$missing" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Deploy secrets not set — build verified, upload skipped. See README for the required secrets."
+            echo "::notice::Build verified, upload skipped — missing secret(s):$missing"
           fi
 
       - name: Configure SSH

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ alternate link in `src/components/SEO.astro`.
 Pushing to `main` triggers `.github/workflows/deploy.yml`: `npm ci` →
 `astro build` → `rsync -avz --delete dist/` to the origin over SSH.
 
-Required repository secrets (environment: `production`):
+Required repository secrets (*Settings → Secrets and variables → Actions*):
 
 | Secret                | Value                                            |
 | --------------------- | ------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Required repository secrets (*Settings → Secrets and variables → Actions*):
 | `DEPLOY_KNOWN_HOSTS`  | Output of `ssh-keyscan -p <port> <host>`         |
 | `DEPLOY_HOST`         | Origin hostname                                  |
 | `DEPLOY_USER`         | SSH user                                         |
-| `DEPLOY_PATH`         | Absolute path to the web root, e.g. `/var/www/vhosts/.../httpdocs` |
+| `DEPLOY_PATH`         | `httpdocs` — deliberately relative to the login home, so it resolves correctly whether or not the SSH user is chrooted |
 | `DEPLOY_PORT`         | Optional, defaults to `22`                       |
 
 The workflow verifies `dist/index.html` and `dist/.htaccess` exist and that at


### PR DESCRIPTION
Three fixes. The first two were on `astro-rebuild` but landed after #19 was merged, so they never reached `main`.

### 1. Remove `environment: production` (blocking)

`main` currently declares `environment: production`, but the deploy secrets are set at **repo** scope — GitHub's environment-secrets API was down when we set them. The workflow therefore reads five empty values and skips the upload on every run, reporting success while never deploying. This is the one that would have had us staring at a green check wondering why the site never changed.

### 2. `DEPLOY_PATH` documented as home-relative

The Plesk SSH user is chrooted, so `/var/www/vhosts/.../httpdocs` does not resolve inside the jail. `httpdocs`, relative to the login home, is correct either way.

### 3. Gate the deploy on `DEPLOY_KNOWN_HOSTS` (the actual bug)

The guard checked four secrets but not `DEPLOY_KNOWN_HOSTS`. With the other four present, the gate would open, `Configure SSH` would write an empty `known_hosts`, and the run would fail on host key verification rather than skipping cleanly. The check now covers all five and names which are missing.

Verified: no tabs in the YAML, `environment:` gone, guard covers all five secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)