### PR TITLE
Fix internship tense and DentechSync attribution

### DIFF
--- a/src/data/now.ts
+++ b/src/data/now.ts
@@ -16,6 +16,7 @@ export const NOW = {
       items: [
         "Deepening my knowledge of .NET and C# for backend and API development.",
         "Getting more comfortable with TypeScript, React, and building complete applications end to end.",
+        "Building and running DentechSync in production at Dentech — a system connecting internal tools and automating operational workflows.",
         "Learning to think more about architecture, maintainability, deployment, and reliability instead of only making features work.",
       ],
     },
@@ -31,7 +32,6 @@ export const NOW = {
       title: "Building on the side",
       items: [
         "OpenCaptive — an open-source captive portal platform, currently being shaped into a proper multi-tenant product.",
-        "DentechSync — an internal platform for connecting systems and automating operational workflows.",
         "This portfolio — built in Astro as a fast, static site and used as a place to document the work.",
       ],
     },

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -31,7 +31,7 @@ const sections = [
     title: 'I learn by building',
     paragraphs: [
       'A large part of my development happens outside the classroom. I build projects to understand technologies properly, test ideas, and solve problems that interest me.',
-      'Projects such as OpenCaptive and DentechSync have taught me as much about architecture, deployment, integrations, authentication, observability, and product thinking as they have about writing code.',
+      'Personal projects such as OpenCaptive have taught me about architecture, multi-tenancy, and product thinking. Building and maintaining DentechSync — a production system at Dentech — has taught me just as much about deployment, integrations, and operating software other people depend on every day.',
     ],
   },
   {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,7 +8,7 @@ import { EMAIL, SOCIALS } from '../consts';
 const welcome = [
   'Conversations about .NET, TypeScript, React, APIs, and systems-aware engineering.',
   'Collaborative work where learning, structure, and technical quality are central.',
-  'Opportunities that follow on from my current internship.',
+  'Opportunities that follow on from my upcoming internship at Basic-Fit.',
 ];
 
 const channels = [
@@ -42,9 +42,9 @@ const channels = [
 >
   <PageHeader label="Contact">
     <span slot="title">Open to the right conversations.</span>
-    I am currently interning with the IT/AI team at Basic-Fit, and open to
-    technical discussions, collaborations, and opportunities that fit my current
-    stage of development.
+    I'm starting an internship with the IT/AI team at Basic-Fit on 31 August,
+    and I'm open to technical discussions, collaborations, and opportunities
+    that fit my current stage of development.
   </PageHeader>
 
   <div class="wrap">


### PR DESCRIPTION
Two content accuracy issues, found while cross-checking the live site against
current facts.

## Internship tense

The Basic-Fit internship starts **31 August** — it hasn't started yet.
`contact.astro` was still saying *"I am currently interning"* and *"my
current internship."* `now.ts` and `about.astro` already used the correct
"preparing for" / "upcoming" phrasing; `contact.astro` was the one page left
on the old wording, which also made it inconsistent with the rest of the site.

## DentechSync attribution

`about.astro` and `now.ts` both listed **DentechSync** next to **OpenCaptive**
as something built outside work — under "Building on the side," described as
a "project" that "taught me" things, same framing as a personal OSS repo.

DentechSync was built on paid hours, for Dentech. It isn't a side project.
Reworded both mentions to say what's actually true — he built and runs it in
production at his employer — and moved it out of the personal-projects list
into the work-experience section. That's a stronger claim for a portfolio to
make, not a weaker one, and it doesn't misrepresent ownership.

## Verification

- `astro check` — 0 errors, 0 warnings, 0 hints
- 11 pages built
- No remaining "currently interning" / "current internship" strings anywhere in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)